### PR TITLE
Adding a dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
 ssl/*.key
 ssl/*.pem
 ssl/*.csr
-/mutateme
+mutateme
 
 # Ignore git directories
 .git

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+ssl/*.key
+ssl/*.pem
+ssl/*.csr
+/mutateme
+
+# Ignore git directories
+.git
+.gitignore


### PR DESCRIPTION
Reduces context by ignoring git directories, this will prevent docker builds getting slower and slower over time as the repo grows. 
Prevents cert leakage too by ignoring them.

Previously
`Sending build context to Docker daemon    8.5MB`

Now
`Sending build context to Docker daemon  7.175MB`
