### PR TITLE
Update ssh.sh to supported K8s version

### DIFF
--- a/ssl/csr.conf
+++ b/ssl/csr.conf
@@ -1,7 +1,10 @@
 [req]
 req_extensions = v3_req
 distinguished_name = req_distinguished_name
+prompt = no
 [req_distinguished_name]
+O = system:nodes
+CN = system:node:mutateme.default.svc
 [ v3_req ]
 basicConstraints = CA:FALSE
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment


### PR DESCRIPTION
Api version certificates.k8s.io/v1 (v1beta1 is not supported any longer) has some new constraints, like:

* A `signerName` is required and should be `kubernetes.io/kubelet-serving`
* The Organization must be `system:nodes`
* The CN must begin with `system:node:`

Please see:
https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/

Also some bugs in the script is fixed:
* SECONDS was never updated
* The `[[` operator is not available for `/bin/sh` on Ubuntu (uses dash) and it's not needed here
